### PR TITLE
zig 0.14.1 changed file name schema

### DIFF
--- a/plugins/zig.toml
+++ b/plugins/zig.toml
@@ -5,9 +5,9 @@ name = "zig"
 type = "cli"
 
 [platform.linux]
-archive-prefix = "zig-linux-{arch}-{version}"
-download-file = "zig-linux-{arch}-{version}.tar.xz"
-checksum-file = "zig-linux-{arch}-{version}.tar.xz.minisig"
+archive-prefix = "zig-{arch}-linux-{version}"
+download-file = "zig-{arch}-linux-{version}.tar.xz"
+checksum-file = "zig-{arch}-linux-{version}.tar.xz.minisig"
 
 [platform.macos]
 archive-prefix = "zig-macos-{arch}-{version}"

--- a/plugins/zig.toml
+++ b/plugins/zig.toml
@@ -10,14 +10,14 @@ download-file = "zig-{arch}-linux-{version}.tar.xz"
 checksum-file = "zig-{arch}-linux-{version}.tar.xz.minisig"
 
 [platform.macos]
-archive-prefix = "zig-macos-{arch}-{version}"
-download-file = "zig-macos-{arch}-{version}.tar.xz"
-checksum-file = "zig-macos-{arch}-{version}.tar.xz.minisig"
+archive-prefix = "zig-{arch}-macos-{version}"
+download-file = "zig-{arch}-macos-{version}.tar.xz"
+checksum-file = "zig-{arch}-macos-{version}.tar.xz.minisig"
 
 [platform.windows]
-archive-prefix = "zig-windows-{arch}-{version}"
-download-file = "zig-windows-{arch}-{version}.zip"
-checksum-file = "zig-windows-{arch}-{version}.zip.minisig"
+archive-prefix = "zig-{arch}-windows-{version}"
+download-file = "zig-{arch}-windows-{version}.zip"
+checksum-file = "zig-{arch}-windows-{version}.zip.minisig"
 
 [install]
 checksum-public-key = "RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"


### PR DESCRIPTION
not really sure what the best option would be but zig 0.14.1 changed the way the file name is set up :(
ill pop the pull request in anyway so i can still use the plugin but im not really expecting you to accept seeing as it will mess with the downloads of older versions.