### PR TITLE
Fix kubectl download-url for v1.31.x+ (Fixes #1)

### DIFF
--- a/plugins/kubectl.toml
+++ b/plugins/kubectl.toml
@@ -14,7 +14,7 @@ download-file = "darwin/{arch}/kubectl"
 download-file = "windows/{arch}/kubectl.exe"
 
 [install]
-download-url = "https:/storage.googleapis.com/kubernetes-release/release/v{version}/bin/{download_file}"
+download-url = "https://dl.k8s.io/release/v{version}/bin/{download_file}"
 unpack = false
 
 [install.arch]


### PR DESCRIPTION
Summary:
The download urls for kubectl changed over the years and this plugin is well out-of-date.  Thanks to @firleaf for pointing this out.